### PR TITLE
docs: disable viewcode extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Add the extension to your ``conf.py``
    ]
 
 
+Make sure you disable the ``sphinx.ext.viewcode`` extension, as it will conflict with ``sphinx-inlinecode``
 
 Documentation
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Wasn't obvious to me that this does NOT build on top of that extension vs replacing it
